### PR TITLE
monsterId options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5597,6 +5597,12 @@
         }
       }
     },
+    "jest-expect-message": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/jest-expect-message/-/jest-expect-message-1.0.2.tgz",
+      "integrity": "sha512-WFiXMgwS2lOqQZt1iJMI/hOXpUm32X+ApsuzYcQpW5m16Pv6/Gd9kgC+Q+Q1YVNU04kYcAOv9NXMnjg6kKUy6Q==",
+      "dev": true
+    },
     "jest-get-type": {
       "version": "25.2.6",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",

--- a/package.json
+++ b/package.json
@@ -39,10 +39,13 @@
     "eslint": "6.8.0",
     "eslint-config-airbnb-base": "14.1.0",
     "eslint-plugin-import": "2.20.2",
-    "husky": "^4.2.5",
+    "husky": "4.2.5",
     "jest": "25.4.0",
-    "lint-staged": "^10.1.7",
-    "sinon": "9.0.2"
+    "jest-expect-message": "1.0.2",
+    "lint-staged": "10.1.7"
+  },
+  "jest": {
+    "setupFilesAfterEnv": ["jest-expect-message"]
   },
   "husky": {
     "hooks": {

--- a/src/monsterId.js
+++ b/src/monsterId.js
@@ -1,9 +1,18 @@
 import gd from 'node-gd';
 import { fromString } from './utils/randomNumber';
 
-const DEFAULT_SIZE = 120;
+const defaultOptions = {
+  size: 120,
+};
 
-async function fillParts(avatar, getRandomNumber) {
+export default async function monsterid(username = '', options = defaultOptions) {
+  const { size } = options;
+  const getRandomNumber = fromString(username);
+  const monster = await gd.createTrueColor(size, size);
+  const color = monster.colorAllocate(255, 255, 255);
+
+  monster.fill(0, 0, color);
+
   const parts = {
     legs: getRandomNumber(1, 5),
     hair: getRandomNumber(1, 5),
@@ -18,10 +27,10 @@ async function fillParts(avatar, getRandomNumber) {
     const path = `${__dirname}/../images/parts/${part}_${parts[part]}.png`;
     // eslint-disable-next-line no-await-in-loop
     const image = await gd.createFromPng(path);
-    image.copy(avatar, 0, 0, 0, 0, DEFAULT_SIZE, DEFAULT_SIZE);
+    image.copy(monster, 0, 0, 0, 0, size, size);
 
     if (part === 'body') {
-      avatar.fill(0, 0, avatar.colorAllocate(
+      monster.fill(0, 0, monster.colorAllocate(
         getRandomNumber(55, 200),
         getRandomNumber(55, 200),
         getRandomNumber(55, 200),
@@ -29,15 +38,5 @@ async function fillParts(avatar, getRandomNumber) {
     }
   }
 
-  return avatar.pngPtr();
-}
-
-export default async function monsterid(username = '') {
-  const getRandomNumber = fromString(username);
-  const image = await gd.createTrueColor(DEFAULT_SIZE, DEFAULT_SIZE);
-  const color = image.colorAllocate(255, 255, 255);
-
-  image.fill(0, 0, color);
-
-  return fillParts(image, getRandomNumber);
+  return monster.pngPtr();
 }


### PR DESCRIPTION
### DESCRIPTION

The monsterId function now accepts an optional configuration object w…th a size property, that can be used to specify the desired size of the avatar.

- Refactor monsterId in a single function
- Refactor tests to only use Jest for mock functionality
- Add jest-expect-message in order to keep assertion's messages
- Get rid of Sinon :'(